### PR TITLE
Fix integration test caching issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test:
 
 test-integration:
 	@echo "Running integration tests..."
-	@go test -v ./test/integration/...
+	@go test -count=1 -v ./test/integration/...
 
 test-e2e:
 	@echo "Running E2E tests..."
@@ -86,7 +86,7 @@ docker-test:
 
 docker-test-integration:
 	@echo "Running integration tests in Docker container with PostgreSQL..."
-	@docker-compose -f docker-compose.test.yml run --rm voidrunner-test go test -v ./test/integration/...
+	@docker-compose -f docker-compose.test.yml run --rm voidrunner-test go test -count=1 -v ./test/integration/...
 	@docker-compose -f docker-compose.test.yml down
 
 docker-test-e2e:

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ make run            # Build and run the application (starts server on :8080)
 #### Test Commands
 ```bash
 make test           # Run unit tests with coverage
-make test-integration # Run integration tests
+make test-integration # Run integration tests (always fresh, no caching)
 make test-e2e       # Run end-to-end tests (use STORAGE_BACKEND env var for backend selection)
 make test-all       # Run all test suites (unit, integration, E2E)
 
@@ -247,12 +247,13 @@ DETACH=1 make docker-up
 #### Docker Test Commands
 ```bash
 make docker-test              # Run unit tests in Docker container
-make docker-test-integration  # Run integration tests with PostgreSQL in Docker
+make docker-test-integration  # Run integration tests with PostgreSQL in Docker (always fresh, no caching)
 make docker-test-e2e          # Run E2E tests with both backends in Docker
 make docker-test-all          # Run all test suites in Docker containers
 
 # Note: Docker test commands use isolated test containers and databases
 # They automatically handle service dependencies and cleanup
+# Integration tests run fresh every time to ensure external database state changes are detected
 ```
 
 #### Documentation Commands
@@ -286,7 +287,7 @@ The project uses a comprehensive three-tier testing approach with both local and
 
 #### Test Types
 - **Unit Tests**: Mock-based testing with coverage reporting (no external dependencies)
-- **Integration Tests**: Real PostgreSQL database with complete HTTP testing
+- **Integration Tests**: Real PostgreSQL database with complete HTTP testing (always run fresh to detect database state changes)
 - **E2E Tests**: Full application testing with both memory and PostgreSQL backends
 
 #### Execution Options


### PR DESCRIPTION
## Summary

- Fix integration test caching issue that was masking database connection failures
- Add `-count=1` flag to integration test commands to ensure fresh execution
- Update documentation to reflect the change and explain the importance

## Problem

Integration tests were using Go's test cache, which could return stale PASS results from previous runs when PostgreSQL was available. This masked real connection failures when the database was unavailable, leading to false positive test results.

## Solution

- **Makefile changes**: Added `-count=1` flag to both `test-integration` and `docker-test-integration` commands
- **Documentation updates**: Updated README to explain that integration tests run fresh and why this is important
- **Consistency**: Applied the fix to both local and Docker test commands

## Test Plan

- [x] Verified integration tests properly fail when no PostgreSQL database is available
- [x] Confirmed tests run fresh every time (no cached results)
- [x] Tested both `make test-integration` and the corresponding Docker command
- [x] Updated documentation reflects the changes

## Why This Matters

Integration tests depend on external database state and should always reflect the current environment. Caching can hide real issues where:
- Database is not available
- Database configuration has changed
- Database state differs from previous runs

This fix ensures integration tests provide reliable feedback about the actual system state.

🤖 Generated with [Claude Code](https://claude.ai/code)